### PR TITLE
added API_URL as required in app.json env for deployment

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,9 @@
   "scripts": {
   },
   "env": {
+    "REACT_APP_API_URL": {
+      "required": true
+    }
   },
   "formation": {
   },


### PR DESCRIPTION
This code in the env section of app.json lets review apps bring in the API_URL in from the master config var. The change is for quality of life so we don't have to continuously manually add the API_URL for every review app.